### PR TITLE
Remove extract from shortcode atts, it's bad practice

### DIFF
--- a/inc/icons.php
+++ b/inc/icons.php
@@ -15,14 +15,16 @@ function get_svg_icon( $id, $atts = array() ) {
         return;
     }
 
-    extract( shortcode_atts(
+    $atts = shortcode_atts(
         array(
             'class' => null,
             'title' => null
             // maybe we want to add desc (<desc>) for even more a11y
         ),
         $atts
-    ));
+    );
+    $class = $atts['class'];
+    $title = $atts['title'];
 
     // check if this ID will be in the sprite
     if ( ! file_exists( TEMPLATEPATH . '/dist/icons/' . $id . '.svg' ) ) {


### PR DESCRIPTION
Hallo. :)

War gestern auch auf dem Vortrag und hab mir deswegen auch gleich mal deine Funktion angeschaut, da ich auch im WP-Universe unterwegs bin.

Dabei ist mir aufgefallen, dass du extract nutzt. Das wurde irgendwann mal aus dem Core verbannt, weil es als Bad Practice gilt, siehe:
https://core.trac.wordpress.org/ticket/22400

Theoretisch ist dann mein PR auch nicht viel besser, weil ich am Ende wieder $title und $class nutze statt $atts['class'], aber ich dachte, bevor ich zu später Stunde noch mehr im Code rumfummel. :)